### PR TITLE
Install kernel-headers in the image

### DIFF
--- a/stages/03-Packages/00-run-chroot.sh
+++ b/stages/03-Packages/00-run-chroot.sh
@@ -8,9 +8,16 @@
 sudo systemctl stop dhcpcd.service
 sudo systemctl disable dhcpcd.service
 
+# Remove bad and unnecessary symlinks 
+rm /lib/modules/4.14.71*/build
+rm /lib/modules/4.14.71*/source
+
+# Install kernel-headers before apt-get update
+DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install raspberrypi-kernel-headers
+
 # Latest package source
-sudo rm -rf /var/lib/apt/lists/*
-sudo apt-get clean
+# sudo rm -rf /var/lib/apt/lists/*
+# sudo apt-get clean
 sudo apt-get update
 
 # Install essentials
@@ -19,6 +26,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install aircrack-ng
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install gnuplot
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install udhcpd
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install socat
+DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install --assume-no wireshark-common
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install tshark
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install ser2net
 DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install gstreamer1.0-tools


### PR DESCRIPTION
With this (well tested) PR,

- good version (4.14.71) of kernel-headers are installed in the image (/usr/src),
- good symlinks are created in /lib/modules/...
- wireshark-common is installed, but already asks the f... question,
- tshark is also installed.

With this PR, Luke shouldn't anymore has problems with v4l2loopback ...