### PR TITLE
v4l2loopback make for stage 4 01-chroot

### DIFF
--- a/stages/04-Wifibroadcast/01-run-chroot.sh
+++ b/stages/04-Wifibroadcast/01-run-chroot.sh
@@ -13,7 +13,9 @@ cd flir
 cd v4l2loopback
 sudo make 
 sudo make install
-sudo depmod -a 
+
+# COMMENTED OUT AS IT IS CAUSING FATAL ERROR DUE TO WRONG VERSION (uname issue)
+#sudo depmod -a 
 
 cd /home/pi/flir
 sudo git clone https://github.com/fnoop/flirone-v4l2.git

--- a/stages/04-Wifibroadcast/01-run-chroot.sh
+++ b/stages/04-Wifibroadcast/01-run-chroot.sh
@@ -4,12 +4,21 @@
 
 #!/bin/bash
 
-# Install v4l2loopback
+# Install OpenVG and flir stuff
 cd /home/pi
+sudo mkdir /home/pi/flir
+sudo mv v4l2loopback /home/pi/flir
+
+cd flir
 cd v4l2loopback
 sudo make 
 sudo make install
-sudo depmod -a
+sudo depmod -a 
+
+cd /home/pi/flir
+sudo git clone https://github.com/fnoop/flirone-v4l2.git
+cd flirone-v4l2
+sudo make
 
 # Install OpenVG
 cd /home/pi

--- a/stages/04-Wifibroadcast/01-run-chroot.sh
+++ b/stages/04-Wifibroadcast/01-run-chroot.sh
@@ -4,6 +4,13 @@
 
 #!/bin/bash
 
+# Install v4l2loopback
+cd /home/pi
+cd v4l2loopback
+sudo make 
+sudo make install
+sudo depmod -a
+
 # Install OpenVG
 cd /home/pi
 cd openvg


### PR DESCRIPTION
Make request for v4l2loopback. Currently fails in builder due to incorrect uname -r being returned but in live image it makes successfully.